### PR TITLE
Update to 1.6.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ libav-10.6.tar.xz
 gst-libav-1.6.1.tar.xz
 gst-libav-1.6.2.tar.xz
 gst-libav-1.6.3.tar.xz
+gst-libav-1.6.4.tar.xz

--- a/gstreamer1-libav.spec
+++ b/gstreamer1-libav.spec
@@ -1,5 +1,5 @@
 Name:           gstreamer1-libav
-Version:        1.6.3
+Version:        1.6.4
 Release:        1%{?dist}
 Summary:        GStreamer 1.0 libav-based plug-ins
 Group:          Applications/Multimedia
@@ -62,7 +62,8 @@ rm $RPM_BUILD_ROOT%{_libdir}/gstreamer-1.0/libgst*.la
 
 
 %files
-%doc AUTHORS COPYING.LIB ChangeLog NEWS README TODO
+%doc AUTHORS ChangeLog NEWS README TODO
+%license COPYING.LIB
 %{_libdir}/gstreamer-1.0/libgstlibav.so
 
 %files devel-docs
@@ -71,6 +72,9 @@ rm $RPM_BUILD_ROOT%{_libdir}/gstreamer-1.0/libgst*.la
 
 
 %changelog
+* Sat May 21 2016 Hans de Goede <j.w.r.degoede@gmail.com> - 1.6.4-1
+- Update to 1.6.4
+
 * Sat Jan 23 2016 Hans de Goede <j.w.r.degoede@gmail.com> - 1.6.3-1
 - Update to 1.6.3
 

--- a/sources
+++ b/sources
@@ -1,1 +1,1 @@
-cfe9a06913d4fd4067e9e47f6e05fac2  gst-libav-1.6.3.tar.xz
+d9922f6246f4ff0472d0ac3ada287f52  gst-libav-1.6.4.tar.xz


### PR DESCRIPTION
Update rpmfusion gstreamer1-\* f23 packages to 1.6.4, to bring them in sync with their Fedora counterparts.

tarbals have been uploaded to the look-a-side cache already.
