### PR TITLE
Update to 1.8.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ gst-libav-1.6.1.tar.xz
 gst-libav-1.6.2.tar.xz
 gst-libav-1.6.3.tar.xz
 gst-libav-1.8.1.tar.xz
+gst-libav-1.8.2.tar.xz

--- a/gstreamer1-libav.spec
+++ b/gstreamer1-libav.spec
@@ -1,5 +1,5 @@
 Name:           gstreamer1-libav
-Version:        1.8.1
+Version:        1.8.2
 Release:        1%{?dist}
 Summary:        GStreamer 1.0 libav-based plug-ins
 Group:          Applications/Multimedia
@@ -69,6 +69,9 @@ rm $RPM_BUILD_ROOT%{_libdir}/gstreamer-1.0/libgst*.la
 
 
 %changelog
+* Sun Jun 12 2016 Hans de Goede <j.w.r.degoede@gmail.com> - 1.8.2-1
+- Update to 1.8.2
+
 * Wed May 18 2016 Hans de Goede <j.w.r.degoede@gmail.com> - 1.8.1-1
 - Update to 1.8.1
 

--- a/sources
+++ b/sources
@@ -1,1 +1,1 @@
-85f1a047606ca9e08493d7b6b42df462  gst-libav-1.8.1.tar.xz
+95bc3dd0ea2dc664b4f3a96897005013  gst-libav-1.8.2.tar.xz


### PR DESCRIPTION
Update rpmfusion gstreamer pkgs to 1.8.2, to bring them in sync with F24, tarballs have already been uploaded to the (old) look-a-side cache.
